### PR TITLE
Added spine side option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,13 @@ two images with one image per page.
 
 Requires the RMagick gem.
 
+```
+Usage: autosplit [options] filename
+      -n, --no_detect                  Do not attempt to detect the spine, but split images down the middle
+      -l, --line_only                  Draw a line on autodetected spine and write new image to .autosplit files
+      -v, --vertical                   Split images vertically (for notebook bindings)
+      -f, --fudge_factor NUM           Percentage of 'slop' to add over autodetected spine when cropping. (default 2)
+      -h, --help   
+```
+
 Released under the MIT license


### PR DESCRIPTION
Many images have spines on the left hand or right hand side of the image.  If you need to merge across these leaves into one opening image, the spines and any page "beyond" the spine need to be removed so that the resulting images could be combined where the spine used to be.  I added the -s --spine-side option that looks in the left or right 20% of the image and splits on the spine found within that area, saving only the main portion of the image.